### PR TITLE
Changes to organization of data_metrics vignettes

### DIFF
--- a/vignettes/Data_Metrics.Rmd
+++ b/vignettes/Data_Metrics.Rmd
@@ -11,9 +11,6 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-where do changes go?
-
-donde?
 
 You can normalize or transform your raw data after succesfully uploading it. We provide two simple data metrics to help identify samples that deviate from the majority of samples, which may indicate potential low-quality samples that can be removed before downstream analysis.
 


### PR DESCRIPTION
I just made a few changes to the organization and structure of the vignette. 

1) I placed the descriptions of data normalization methods in the normalization section
2)I added short descriptions of transformation methods in the transformation section (I don't know how accurate they are, definitely change them if they aren't true).
3)I changed the description of gene coverage slightly. 
4)Corrected a few spellings and grammar

I don't know if you like the changes, they may not be what you are looking for - I'll take a look at the other vignette you updated tomorrow!

-Toby
