### PR TITLE
Organize heatmap based on NMF

### DIFF
--- a/inst/sake/server.r
+++ b/inst/sake/server.r
@@ -895,6 +895,13 @@ shinyServer(function(input, output, session) {
       heatmap_data <- heatmap_data[, idx]
     }
 
+    else if(input$OrdCol == 'nmf') {#Add options to sort by nmf groups
+      nmf_subtypes <- nmf_groups()$nmf_subtypes
+      idx <- order(sapply(nmf_subtypes, function(x) x[[input$sortcolumn_num]]))
+      heatmap_data <- heatmap_data[, idx]
+
+    }
+
     res <- list()
     res[["heatmap_data"]] <- heatmap_data
     res[["genelist"]] <- genelist
@@ -919,11 +926,28 @@ shinyServer(function(input, output, session) {
   })
 
   ColSideColors <- reactive({
-    heatmap_data <- heatmap_data()[['heatmap_data']]
-    res <- name_to_color(colnames(heatmap_data), split_pattern ="\\_",
-                         num_color = input$ColSideColorsNum,
-                         ColScheme = ColScheme()[1:input$ColSideColorsNum] )
-    return(res)
+
+    #     heatmap_data <- heatmap_data()[['heatmap_data']]
+    #    res <- name_to_color(colnames(heatmap_data), split_pattern ="\\_",
+    #                          num_color = input$ColSideColorsNum,
+    #                           ColScheme = ColScheme()[1:input$ColSideColorsNum] )
+    #      return(res)
+
+    if(input$ColClr=='nmf'){
+      heatmap_data <- heatmap_data()[['heatmap_data']]
+      nmf_subtypes <- nmf_groups()$nmf_subtypes
+      res <- create.brewer.color(nmf_subtypes, length(unique(nmf_subtypes)), "naikai")
+      return(res)
+    }
+
+    else if(input$ColClr == 'group'){
+      heatmap_data <- heatmap_data()[['heatmap_data']]
+      res <- name_to_color(colnames(heatmap_data), split_pattern ="\\_",
+                           num_color = input$ColSideColorsNum,
+                           ColScheme = ColScheme()[1:input$ColSideColorsNum] )
+      return(res)
+    }
+
   })
 
   RowSideColors <- reactive({
@@ -1061,7 +1085,7 @@ shinyServer(function(input, output, session) {
   )
 
   plot_colopts <- reactive({
-    c("Default", "Filename", "GeneExpr")
+    c("Default", "Filename", "GeneExpr","NMF")
   })
   observeEvent(rawdata(), {
     updateSelectizeInput(session, 'pt_col',

--- a/inst/sake/ui.R
+++ b/inst/sake/ui.R
@@ -577,6 +577,7 @@ body <- dashboardBody(
                         column(width=3,
                                selectInput("OrdCol", "Cluster column?",
                                            choices = list("Default ordering" = "default",
+                                                          "NMF group" = "nmf",
                                                           "Hierarchical" = "hier",
                                                           "Group info" = "group",
                                                           "Gene Expression" = "gene"),
@@ -595,9 +596,20 @@ body <- dashboardBody(
                         ),
                         column(width=3, selectInput("OrdRow", "Cluster row?",
                                                     choices = list("Default ordering" = "default",
+                                                                   "NMF group" = "nmf",
                                                                    "Hierarchical" = "hier"),
-                                                    selected = "hier"))
+                                                    selected = "hier")),
+
+                        column(width=3, selectInput("ColClr", "Cluster color?",
+                                                    choices = list("NMF group" = "nmf",
+                                                                   "Group info" = "group"),
+                                                    selected = "group")
+                        )
+
+
                       )
+
+
                     ),
                     conditionalPanel(
                       condition = "input.heat_opttype == 'scale'",


### PR DESCRIPTION
I added the option to organize the heatmap based on NMF groups.

I was unable to figure out how to change the column colors to correspond to NMF groups. They still get colored based on the filename groups. Could you look at the code I added to attempt to do this and see what is wrong? It's on the server side under ColSideColors. Thanks!

I will take a look at the vignette now. 
